### PR TITLE
limit parameter for Poloniex API endpoint `public/?command=returnLoanOrders` incorporated into `Poloniex#loan_orders` method

### DIFF
--- a/lib/poloniex.rb
+++ b/lib/poloniex.rb
@@ -48,8 +48,8 @@ module Poloniex
     get 'returnCurrencies'
   end
 
-  def self.loan_orders(currency)
-    get 'returnLoanOrders', currency: currency
+  def self.loan_orders(currency, limit)
+    get 'returnLoanOrders', currency: currency, limit: limit
   end
 
   def self.balances

--- a/lib/poloniex/version.rb
+++ b/lib/poloniex/version.rb
@@ -1,3 +1,3 @@
 module Poloniex
-  VERSION = "1.0.4"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
- Newly discovered limit parameter for Poloniex API endpoint `public/?command=returnLoanOrders` that allows control over how many loan orders are returned has been incorporated into `Poloniex#loan_orders` method

- Version bump to 1.1.0